### PR TITLE
refactor: main js

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,30 +1,54 @@
-import {html , render} from 'https://unpkg.com/lit-html?module'
-// Nanny State function
-const Nanny = (state={},{ element=state.element || document.body,view=state.view || `NANNY STATE`,before=state.before,after=state.after,debug=state.debug,logState=state.logState}={}) => {
-  // initial render
-  render(view(state),element);
-  // log the state if in debug mode
-  if(debug || logState) console.log(state);
-  // return update function
-  return (transformer,...params) => {
-    // call before function here
-    if(before) before(state);
-    // update state based on the action and params submitted
-    const newState = typeof transformer(state) === "function" ? 
-                            params.length ? transformer(state)(...params) : transformer(state)() 
-                            : transformer(state);
-    // check if the state is an object. If it is, create a copy and augment any changes to it
-    state = Object.prototype.toString.call(state) === "[object Object]"
-                     ? { ...state,...newState}
-                     : newState;
-    // call after function here
-    if(after) after(state);
-    // render the new state
-    render(view(state),element);
-    // log the state if in debug mode
-    if(debug || logState) console.log(state);
-    // return the new state
-    return state;
+import { html, render } from "https://unpkg.com/lit-html?module";
+
+const Nanny = (
+  state = {},
+  {
+    element = state.element || document.body,
+    view = state.view || `NANNY STATE`,
+    before = state.before,
+    after = state.after,
+    debug = state.debug,
+    logState = state.logState,
+  } = {}
+) => {
+  render(view(state), element);
+
+  if (debug || logState) {
+    console.log(state);
   }
-}
-export { Nanny,html }
+
+  return (transformer, ...params) => {
+    if (before) {
+      before(state);
+    }
+
+    // Update state based on the action and params submitted
+    const newState =
+      typeof transformer(state) === "function"
+        ? params.length
+          ? transformer(state)(...params)
+          : transformer(state)()
+        : transformer(state);
+
+    // If the state is an object, create a copy and augment any changes to it
+    state =
+      Object.prototype.toString.call(state) === "[object Object]"
+        ? { ...state, ...newState }
+        : newState;
+
+    if (after) {
+      after(state);
+    }
+
+    // Render the new state
+    render(view(state), element);
+
+    if (debug || logState) {
+      console.log(state);
+    }
+
+    return state;
+  };
+};
+
+export { Nanny, html };

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 import { html, render } from "https://unpkg.com/lit-html?module";
 
-const Nanny = (
+function Nanny(
   state = {},
   {
     element = state.element || document.body,
@@ -10,7 +10,7 @@ const Nanny = (
     debug = state.debug,
     logState = state.logState,
   } = {}
-) => {
+) {
   render(view(state), element);
 
   if (debug || logState) {
@@ -49,6 +49,6 @@ const Nanny = (
 
     return state;
   };
-};
+}
 
 export { Nanny, html };

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ function Nanny(
     logState = state.logState,
   } = {}
 ) {
+  // Initial state.
   render(view(state), element);
 
   if (debug || logState) {
@@ -22,7 +23,7 @@ function Nanny(
       before(state);
     }
 
-    // Update state based on the action and params submitted
+    // Update state based on the action and params submitted.
     const newState =
       typeof transformer(state) === "function"
         ? params.length
@@ -30,7 +31,7 @@ function Nanny(
           : transformer(state)()
         : transformer(state);
 
-    // If the state is an object, create a copy and augment any changes to it
+    // If the state is an object, create a copy and augment any changes to it.
     state =
       Object.prototype.toString.call(state) === "[object Object]"
         ? { ...state, ...newState }
@@ -40,7 +41,7 @@ function Nanny(
       after(state);
     }
 
-    // Render the new state
+    // Update.
     render(view(state), element);
 
     if (debug || logState) {


### PR DESCRIPTION
- Removed superfluous comments. 
     - The code is meant to be self-explanatory so `debug || logState` actually tells us what the code does so you don't need a comment saying that the check is for debug mode.
    - It actually makes code harder to read and maintain if there are a ton of comments that add no value and their explanation is longer than the actual code. e.g.
        ```js
        // call before function here
        if(before) before(state);
        ```
- Broke if statements over multiple lines for readability and easier to edit.
- Apply Prettier formatting.
    ```sh
    npx prettier main.js
    ```
- Convert outer function from `const` to `function`. Then you don't need a comment explaining that it is a function.

---

I haven't tested the code. I can't get it to run (even on "main" branch) because of errors.

`package.json`
```json
{
    "type": "module",
    "scripts": {
        "start": "node main.js"
    }
}
```

```sh
npm start
```
```
node:internal/process/esm_loader:74
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader. Received protocol 'https:'
```